### PR TITLE
fix: add error response examples to session-insights API

### DIFF
--- a/code/API_definitions/session-insights.yaml
+++ b/code/API_definitions/session-insights.yaml
@@ -939,14 +939,37 @@ components:
 
   responses:
     BadRequest400:
-      description: Bad request
+      description: Bad Request
       headers:
         x-correlator:
           $ref: "#/components/headers/x-correlator"
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+                      - OUT_OF_RANGE
+          examples:
+            GENERIC_400_INVALID_ARGUMENT:
+              description: Invalid Argument. Generic Syntax Exception
+              value:
+                status: 400
+                code: INVALID_ARGUMENT
+                message: Client specified an invalid argument, request body or query param.
+            GENERIC_400_OUT_OF_RANGE:
+              description: Out of Range. Specific Syntax Exception used when a given field has a pre-defined range or a invalid filter criteria combination is requested
+              value:
+                status: 400
+                code: OUT_OF_RANGE
+                message: Client specified an invalid range.
 
     Generic401:
       description: Unauthorized
@@ -966,6 +989,13 @@ components:
                   code:
                     enum:
                       - UNAUTHENTICATED
+          examples:
+            GENERIC_401_UNAUTHENTICATED:
+              description: Request cannot be authenticated and a new authentication is required
+              value:
+                status: 401
+                code: UNAUTHENTICATED
+                message: Request not authenticated due to missing, invalid, or expired credentials.
 
     Forbidden403:
       description: Forbidden
@@ -975,17 +1005,63 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 403
+                  code:
+                    enum:
+                      - PERMISSION_DENIED
+                      - INVALID_TOKEN_CONTEXT
+          examples:
+            GENERIC_403_PERMISSION_DENIED:
+              description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
+              value:
+                status: 403
+                code: PERMISSION_DENIED
+                message: Client does not have sufficient permissions to perform this action.
+            GENERIC_403_INVALID_TOKEN_CONTEXT:
+              description: Reflect some inconsistency between information in some field of the API and the related OAuth2 Token
+              value:
+                status: 403
+                code: INVALID_TOKEN_CONTEXT
+                message: "{{field}} is not consistent with access token."
 
     NotFound404:
-      description: Not found
+      description: Not Found
       headers:
         x-correlator:
           $ref: "#/components/headers/x-correlator"
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
+                      - IDENTIFIER_NOT_FOUND
+          examples:
+            GENERIC_404_NOT_FOUND:
+              description: Resource is not found
+              value:
+                status: 404
+                code: NOT_FOUND
+                message: The specified resource is not found.
+            GENERIC_404_IDENTIFIER_NOT_FOUND:
+              description: Some identifier cannot be matched to a device
+              value:
+                status: 404
+                code: IDENTIFIER_NOT_FOUND
+                message: Device identifier not found.
 
     Conflict409:
       description: Conflict
@@ -995,7 +1071,37 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 409
+                  code:
+                    enum:
+                      - ABORTED
+                      - ALREADY_EXISTS
+                      - CONFLICT
+          examples:
+            GENERIC_409_ABORTED:
+              description: Concurrency of processes of the same nature/scope
+              value:
+                status: 409
+                code: ABORTED
+                message: Concurrency conflict.
+            GENERIC_409_ALREADY_EXISTS:
+              description: Trying to create an existing resource
+              value:
+                status: 409
+                code: ALREADY_EXISTS
+                message: The resource that a client tried to create already exists.
+            GENERIC_409_CONFLICT:
+              description: Duplication of an existing resource
+              value:
+                status: 409
+                code: CONFLICT
+                message: A specified resource duplicate entry found.
 
     Generic410:
       description: Gone
@@ -1015,6 +1121,13 @@ components:
                   code:
                     enum:
                       - GONE
+          examples:
+            GENERIC_410_GONE:
+              description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
+              value:
+                status: 410
+                code: GONE
+                message: Access to the target resource is no longer available.
 
     Generic422:
       description: Unprocessable Content
@@ -1037,6 +1150,31 @@ components:
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
+          examples:
+            GENERIC_422_SERVICE_NOT_APPLICABLE:
+              description: Service not applicable for the provided identifier
+              value:
+                status: 422
+                code: SERVICE_NOT_APPLICABLE
+                message: The service is not available for the provided identifier.
+            GENERIC_422_MISSING_IDENTIFIER:
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the 3-legged access token
+              value:
+                status: 422
+                code: MISSING_IDENTIFIER
+                message: The device cannot be identified.
+            GENERIC_422_UNSUPPORTED_IDENTIFIER:
+              description: None of the provided identifiers is supported by the implementation
+              value:
+                status: 422
+                code: UNSUPPORTED_IDENTIFIER
+                message: The identifier provided is not supported.
+            GENERIC_422_UNNECESSARY_IDENTIFIER:
+              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
+              value:
+                status: 422
+                code: UNNECESSARY_IDENTIFIER
+                message: The device is already identified by the access token.
 
     Generic429:
       description: Too Many Requests
@@ -1057,3 +1195,16 @@ components:
                     enum:
                       - QUOTA_EXCEEDED
                       - TOO_MANY_REQUESTS
+          examples:
+            GENERIC_429_QUOTA_EXCEEDED:
+              description: Request is rejected due to exceeding a business quota limit
+              value:
+                status: 429
+                code: QUOTA_EXCEEDED
+                message: Out of resource quota.
+            GENERIC_429_TOO_MANY_REQUESTS:
+              description: Access to the API has been temporarily blocked due to rate or spike arrest limits being reached
+              value:
+                status: 429
+                code: TOO_MANY_REQUESTS
+                message: Rate limit reached.

--- a/code/API_definitions/session-insights.yaml
+++ b/code/API_definitions/session-insights.yaml
@@ -956,7 +956,6 @@ components:
                   code:
                     enum:
                       - INVALID_ARGUMENT
-                      - OUT_OF_RANGE
           examples:
             GENERIC_400_INVALID_ARGUMENT:
               description: Invalid Argument. Generic Syntax Exception

--- a/code/API_definitions/session-insights.yaml
+++ b/code/API_definitions/session-insights.yaml
@@ -964,7 +964,7 @@ components:
                 code: INVALID_ARGUMENT
                 message: Client specified an invalid argument, request body or query param.
 
-Generic401:
+    Generic401:
       description: Unauthorized
       headers:
         x-correlator:

--- a/code/API_definitions/session-insights.yaml
+++ b/code/API_definitions/session-insights.yaml
@@ -963,14 +963,8 @@ components:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: Client specified an invalid argument, request body or query param.
-            GENERIC_400_OUT_OF_RANGE:
-              description: Out of Range. Specific Syntax Exception used when a given field has a pre-defined range or a invalid filter criteria combination is requested
-              value:
-                status: 400
-                code: OUT_OF_RANGE
-                message: Client specified an invalid range.
 
-    Generic401:
+Generic401:
       description: Unauthorized
       headers:
         x-correlator:


### PR DESCRIPTION
#### What type of PR is this?
correction

#### What this PR does / why we need it:
Adds the missing `examples` section to all error response definitions in `session-insights.yaml`, following the pattern established in `CAMARA_common.yaml` (Commonalities r3.2). This was flagged as a requirement for Commonalities alignment.

- Added `allOf` schema with proper `status` and `code` enums to `BadRequest400`, `Forbidden403`, `NotFound404`, and `Conflict409` (previously using plain `ErrorInfo` references)
- Added `examples` to all 8 error responses:
  - `BadRequest400`: `INVALID_ARGUMENT`, `OUT_OF_RANGE`
  - `Generic401`: `UNAUTHENTICATED`
  - `Forbidden403`: `PERMISSION_DENIED`, `INVALID_TOKEN_CONTEXT`
  - `NotFound404`: `NOT_FOUND`, `IDENTIFIER_NOT_FOUND`
  - `Conflict409`: `ABORTED`, `ALREADY_EXISTS`, `CONFLICT`
  - `Generic410`: `GONE`
  - `Generic422`: `SERVICE_NOT_APPLICABLE`, `MISSING_IDENTIFIER`, `UNSUPPORTED_IDENTIFIER`, `UNNECESSARY_IDENTIFIER`
  - `Generic429`: `QUOTA_EXCEEDED`, `TOO_MANY_REQUESTS`

#### Which issue(s) this PR fixes:
Fixes #71

#### Special notes for reviewers:
PR #84 (issue #70) also modifies `BadRequest400` to add `INVALID_SINK`, `INVALID_CREDENTIAL`, and `INVALID_TOKEN` codes. If #84 merges first, this PR may have a minor conflict in that section -- happy to rebase and resolve.

#### Changelog input
```release-note
Added error response examples to all error definitions following CAMARA_common.yaml r3.2 pattern. Added allOf schema with status and code enums where missing.
```

#### Additional documentation
- [CAMARA_common.yaml (r3.2)](https://github.com/camaraproject/Commonalities/blob/r3.2/artifacts/CAMARA_common.yaml)