### PR TITLE
Add Sync26 intent

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -8,25 +8,25 @@
 repository:
   # How this repository participates in CAMARA releases
   # Options: independent (default) | meta-release
-  release_track: independent
+  release_track: meta-release
 
   # Uncomment and set when planning a meta-release participation:
-  # meta_release: Sync26
+  meta_release: Sync26
 
   # Release tag -- first release for a repository is r1.1
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r1.1
+  target_release_tag: r2.1
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-alpha
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r3.4
-  identity_consent_management_release: r3.3
+  commonalities_release: r4.2
+  identity_consent_management_release: r4.2
 
 # APIs in this repository
 # Replace the placeholder below when planning a release:
@@ -34,8 +34,8 @@ dependencies:
 # - target_api_status: draft | alpha | rc | public (draft allows no file yet)
 apis:
   - api_name: session-insights
-    target_api_version: 0.1.0
-    target_api_status: alpha
+    target_api_version: 0.2.0
+    target_api_status: rc
     main_contacts:
       - benhepworth
       - maheshc01

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,7 +25,7 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.2
+  commonalities_release: r4.3
   identity_consent_management_release: r4.2
 
 # APIs in this repository


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* subproject management


#### What this PR does / why we need it:

Declare intent for Sync26 meta-release

#### Which issue(s) this PR fixes:

none

#### Special notes for reviewers:

SessionInsights just had it's first alpha release and plans on participating in the Sync26 release.

#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
